### PR TITLE
fix: font size bug when exported as pdf

### DIFF
--- a/src/_misty-dark-base.scss
+++ b/src/_misty-dark-base.scss
@@ -340,10 +340,6 @@ code, tt {
     }*/
 }
 @media print {
-    body {
-        font-size: 11px;
-        font-weight: 400;
-    }
     table,
     pre {
         page-break-inside: avoid;

--- a/src/_misty-light-base.scss
+++ b/src/_misty-light-base.scss
@@ -328,10 +328,6 @@ code, tt {
     }*/
 }
 @media print {
-    body {
-        font-size: 11px;
-        font-weight: 400;
-    }
     table,
     pre {
         page-break-inside: avoid;


### PR DESCRIPTION
Hi, I find that when exported as pdf, the font size is fixed. I fix this bug so it will output pdf with font size defined in user preference.